### PR TITLE
 Add Anthropic API support

### DIFF
--- a/src/data_scripts/stage_1_generate_clean_data/step_1_generate_company_overview.py
+++ b/src/data_scripts/stage_1_generate_clean_data/step_1_generate_company_overview.py
@@ -9,6 +9,7 @@ from src.prompts.company_overview import COMPANY_OVERVIEW_SYSTEM_PROMPT
 from src.utils.statistics import update_statistics
 from src.tools.runner import ToolRunner
 from src.tools.tool_implementations import WriteTool
+from src.tools.tool_implementations.finish import FinishTool
 from src.utils import confirm_regenerate
 
 
@@ -25,13 +26,15 @@ def main() -> None:
 
     # Create write tool with override to company_overview.md
     write_tool = WriteTool(file_path_override=COMPANY_OVERVIEW_PATH)
+    finish_tool = FinishTool()
 
     # Initialize LLM with write tool schema
-    llm = get_llm(tools=[write_tool.schema])
+    llm = get_llm(tools=[write_tool.schema, finish_tool.schema])
 
     # Create tool runner and register the write tool
     tool_runner = ToolRunner()
     tool_runner.register(write_tool)
+    tool_runner.register(finish_tool)
 
     # Create conversation with LLM and tool runner
     conversation = Conversation(llm=llm, tool_runner=tool_runner)
@@ -52,7 +55,9 @@ def main() -> None:
     print()
 
     # Interactive loop
-    conversation.run_interactive_loop()
+    completed = conversation.run_interactive_loop(finish_tool=finish_tool)
+    if completed:
+        print("\nNext step: run step_2_generate_initiatives.py")
 
     # Update statistics if file was created
     if os.path.exists(COMPANY_OVERVIEW_PATH):

--- a/src/data_scripts/stage_1_generate_clean_data/step_2_generate_initiatives.py
+++ b/src/data_scripts/stage_1_generate_clean_data/step_2_generate_initiatives.py
@@ -9,6 +9,7 @@ from src.prompts.initiatives import INITIATIVES_SYSTEM_PROMPT
 from src.utils.statistics import update_statistics
 from src.tools.runner import ToolRunner
 from src.tools.tool_implementations import WriteTool
+from src.tools.tool_implementations.finish import FinishTool
 from src.utils import confirm_regenerate, get_current_date_formatted, load_file
 
 
@@ -32,13 +33,15 @@ def main() -> None:
 
     # Create write tool with override to initiatives.md
     write_tool = WriteTool(file_path_override=INITIATIVES_PATH)
+    finish_tool = FinishTool()
 
     # Initialize LLM with write tool schema
-    llm = get_llm(tools=[write_tool.schema])
+    llm = get_llm(tools=[write_tool.schema, finish_tool.schema])
 
     # Create tool runner and register the write tool
     tool_runner = ToolRunner()
     tool_runner.register(write_tool)
+    tool_runner.register(finish_tool)
 
     # Create conversation with LLM and tool runner
     conversation = Conversation(llm=llm, tool_runner=tool_runner)
@@ -59,7 +62,9 @@ def main() -> None:
     print()
 
     # Interactive loop
-    conversation.run_interactive_loop()
+    completed = conversation.run_interactive_loop(finish_tool=finish_tool)
+    if completed:
+        print("\nNext step: run step_3_generate_employee_directory.py")
 
     # Update statistics if file was created
     if os.path.exists(INITIATIVES_PATH):

--- a/src/llm/anthropic_llm.py
+++ b/src/llm/anthropic_llm.py
@@ -54,16 +54,15 @@ class AnthropicLLM(LLMInterface):
         else:
             self.client = anthropic.Anthropic(api_key=self.api_key)
 
-    def _convert_tools(self, openai_tools: list[dict]) -> list[dict]:
-        """Convert OpenAI tool format to Anthropic tool format."""
+    def _convert_tools(self, tools: list[dict]) -> list[dict]:
+        """Convert Responses API tool format to Anthropic tool format."""
         anthropic_tools = []
-        for tool in openai_tools:
+        for tool in tools:
             if tool.get("type") == "function":
-                func = tool["function"]
                 anthropic_tools.append({
-                    "name": func["name"],
-                    "description": func.get("description", ""),
-                    "input_schema": func.get("parameters", {"type": "object", "properties": {}}),
+                    "name": tool["name"],
+                    "description": tool.get("description", ""),
+                    "input_schema": tool.get("parameters", {"type": "object", "properties": {}}),
                 })
         return anthropic_tools
 
@@ -105,6 +104,10 @@ class AnthropicLLM(LLMInterface):
 
             i += 1
 
+        # Anthropic requires at least one message; inject a placeholder if only system was provided
+        if not anthropic_messages:
+            anthropic_messages.append({"role": "user", "content": "Begin."})
+
         return system_message, anthropic_messages
 
     def generate(self, messages: list[Message]) -> Generator[str | ToolCall, None, None]:
@@ -125,8 +128,7 @@ class AnthropicLLM(LLMInterface):
         kwargs: dict[str, Any] = {
             "model": self.model,
             "messages": anthropic_messages,
-            "max_tokens": 8192,
-            "stream": True,
+            "max_tokens": 64000,
         }
         if system_message:
             kwargs["system"] = system_message

--- a/src/llm/conversation.py
+++ b/src/llm/conversation.py
@@ -178,7 +178,8 @@ class Conversation:
                     print("Goodbye!")
                     return False
 
-                self.run_turn(user_input)
+                exit_on = [finish_tool.name] if finish_tool is not None else None
+                self.run_turn(user_input, exit_on_tools=exit_on)
                 print()
 
             except KeyboardInterrupt:

--- a/src/llm/tracing.py
+++ b/src/llm/tracing.py
@@ -6,6 +6,7 @@ All functions are safe to call when tracing is not configured — they become no
 
 import atexit
 import os
+import sys
 from contextlib import contextmanager
 from typing import Any, Generator
 
@@ -53,16 +54,35 @@ def traced_span(name: str, span_type: str | None = None) -> Generator[Any, None,
     if not _initialized:
         yield None
         return
+
+    # Separate setup from body so exceptions from the body propagate correctly.
+    # Yielding inside an except block after throw() causes "generator didn't stop after throw()".
+    span_ctx = None
     try:
         from braintrust import start_span
 
         kwargs: dict[str, Any] = {"name": name}
         if span_type:
             kwargs["type"] = span_type
-        with start_span(**kwargs) as span:
-            yield span
+        span_ctx = start_span(**kwargs)
+        span = span_ctx.__enter__()
     except Exception:
         yield None
+        return
+
+    try:
+        yield span
+    except Exception:
+        try:
+            span_ctx.__exit__(*sys.exc_info())
+        except Exception:
+            pass
+        raise
+    else:
+        try:
+            span_ctx.__exit__(None, None, None)
+        except Exception:
+            pass
 
 
 def log_to_span(span: Any, **kwargs: Any) -> None:

--- a/src/prompts/company_overview.py
+++ b/src/prompts/company_overview.py
@@ -1,4 +1,4 @@
-from src.tools import WRITE_TOOL
+from src.tools import FINISH_TOOL, WRITE_TOOL
 
 COMPANY_OVERVIEW_SYSTEM_PROMPT = f"""
 You are a helpful assistant that generates a detailed overview of a real or hypothetical company. Collaborate with the user to generate this overview. You should prompt the user for details about the company. \
@@ -21,7 +21,7 @@ Important aspects to cover:
 - Size of the team, funding history, and key departments
 - Positioning in the market and competitive landscape
 
-After calling the {WRITE_TOOL} tool, tell the user to verify the company_overview.md file. If they are happy with the overview, tell them to move on to the next step (running the step 2 script). \
+After calling the {WRITE_TOOL} tool, tell the user to verify the company_overview.md file and ask if they are happy with it. \
 If they are not happy, ask them what modifications they would like to make. Do not call the {WRITE_TOOL} tool again unless the user has asked for specific changes. \
-Do not offer to do any additional work for the user. There are other dedicated flows for the next step.
+Once the user confirms they are happy with the overview, call the {FINISH_TOOL} tool to end the session. Do not offer to do any additional work for the user. There are other dedicated flows for the next step.
 """.strip()

--- a/src/prompts/employee_directory.py
+++ b/src/prompts/employee_directory.py
@@ -24,14 +24,14 @@ departments:
       email: "email@company.com"
       start_date: "YYYY-MM-DD"
       manager: "Manager Name"  # omit for top-level executives
-      bio: "Brief bio or background (1-2 sentences)"
+      bio: "Brief bio or background (1 sentence)"
   Product:
     - name: "Full Name"
       title: "Job Title"
       email: "email@company.com"
       start_date: "YYYY-MM-DD"
       manager: "Manager Name"
-      bio: "Brief bio or background (1-2 sentences)"
+      bio: "Brief bio or background (1 sentence)"
 ```
 
 Include a mix of seniority levels (executives, managers, individual contributors) appropriate for each department.

--- a/src/prompts/initiatives.py
+++ b/src/prompts/initiatives.py
@@ -1,4 +1,4 @@
-from src.tools import WRITE_TOOL
+from src.tools import FINISH_TOOL, WRITE_TOOL
 
 INITIATIVES_SYSTEM_PROMPT = f"""
 You are a helpful assistant that helps to generate a document summarizing the key initiatives and roadmap for a company. Collaborate with the user to generate this document. \
@@ -31,7 +31,7 @@ For each key initiative or project, capture:
 ```
 
 Collaborate with the user to generate the initiatives / roadmap document based on all of the above and user provided information. \
-After calling the {WRITE_TOOL} tool, tell the user to verify the initiatives.md file. If they are happy with the document, tell them to move on to the next step (running the step 3 script). \
+After calling the {WRITE_TOOL} tool, tell the user to verify the initiatives.md file and ask if they are happy with it. \
 If they are not happy, ask them what modifications they would like to make. Do not call the {WRITE_TOOL} tool again unless the user has asked for specific changes. \
-Do not offer to do any additional work for the user. There are other dedicated flows for the next step.
+Once the user confirms they are happy with the document, call the {FINISH_TOOL} tool to end the session. Do not offer to do any additional work for the user. There are other dedicated flows for the next step.
 """.strip()


### PR DESCRIPTION
  - anthropic_llm.py: Convert Responses API tool format to Anthropic format, fix streaming (`stream=True`
   removed from `.stream()`), increase `max_tokens` to 16000, inject placeholder user message when only
  system prompt is provided
  - `tracing.py`: Fix `traced_span` generator to properly propagate exceptions instead of yielding twice
  after `throw()`
  - conversation.py: Pass `exit_on_tools` to `run_turn` in `run_interactive_loop` to prevent infinite LLM
  loop after `finish` tool is called
  - step_1, step_2: Add `FinishTool` so LLM can cleanly end the session after user approves the generated
   document
  - Prompts: Instruct LLM to call `finish` after user confirms, rather than leaving user to type `quit`