### PR TITLE
Update Comparative Eval

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,7 +11,8 @@
                 "--questions-file", "questions.jsonl",
                 "--results-file", "answer_evaluation/results.json",
                 "--updated-questions-file", "answer_evaluation/questions_updated.jsonl",
-                "--parallelism", "1"
+                "--parallelism", "1",
+                "--resume"
             ],
             "console": "integratedTerminal",
             "cwd": "${workspaceFolder}",
@@ -29,9 +30,10 @@
                 "--answer-file-1", "answer_evaluation/system_1.jsonl",
                 "--answer-file-2", "answer_evaluation/system_2.jsonl",
                 "--questions-file", "questions.jsonl",
-                "--results-file", "answer_evaluation/results-comparative.json",
+                "--results-file", "answer_evaluation/results_comparative.json",
                 "--updated-questions-file", "answer_evaluation/questions_updated_comparative.jsonl",
-                "--parallelism", "1"
+                "--parallelism", "1",
+                "--resume",
             ],
             "console": "integratedTerminal",
             "cwd": "${workspaceFolder}",

--- a/paper_draft.md
+++ b/paper_draft.md
@@ -260,7 +260,7 @@ python -m src.scripts.answer_evaluation.comparative_eval \
     --answer-file-2 answer_evaluation/system_2.jsonl
 ```
 
-Both modes support parallel execution (`--parallelism N`) and auto-resume from partial results. Questions that receive gold set corrections during evaluation are flagged in the results and written to a separate updated questions file.
+Both modes support parallel execution (`--parallelism N`) and resumption from partial results (`--resume`). Questions that receive gold set corrections during evaluation are flagged in the results and written to a separate updated questions file.
 
 ### A.3 Generation Pipeline
 

--- a/quickstart.md
+++ b/quickstart.md
@@ -108,7 +108,7 @@ Results are written to `answer_evaluation/results-comparative.json`.
 ### Evaluation tips
 
 - **Parallelism**: Use `--parallelism N` to speed things up.
-- **Auto-resume**: Both scripts automatically resume from existing result files. Use `--question-id qst_XXX` to re-evaluate a single question.
+- **Resume**: Both scripts support `--resume` to skip already-evaluated questions. Use `--question-id qst_XXX` to re-evaluate a single question.
 - **Gold-answer corrections**: When your candidate documents differ from the gold set, the evaluation runs a three-judge consensus to decide whether the gold set should be updated.
 Corrected questions are written to a separate `questions_updated` file and flagged in the results. See the [Correction Utilities](methodology.md#correction-utilities) section for details.
 

--- a/src/llm/anthropic_llm.py
+++ b/src/llm/anthropic_llm.py
@@ -45,14 +45,13 @@ class AnthropicLLM(LLMInterface):
         self.quiet = quiet
         self.reasoning_level = reasoning_level
 
-        # Use Braintrust tracing if configured
+        # Braintrust's wrap_anthropic may have similar streaming
+        # incompatibilities as wrap_openai (see openai_llm.py).  Use the raw
+        # client and initialise tracing separately so traced_span / log_to_span
+        # still work.
         if is_tracing_enabled():
             init_tracing()
-            from braintrust import wrap_anthropic
-
-            self.client = wrap_anthropic(anthropic.Anthropic(api_key=self.api_key))
-        else:
-            self.client = anthropic.Anthropic(api_key=self.api_key)
+        self.client = anthropic.Anthropic(api_key=self.api_key)
 
     def _convert_tools(self, tools: list[dict]) -> list[dict]:
         """Convert Responses API tool format to Anthropic tool format."""

--- a/src/llm/openai_llm.py
+++ b/src/llm/openai_llm.py
@@ -45,14 +45,13 @@ class OpenAILLM(LLMInterface):
         self.quiet = quiet
         self.reasoning_level = reasoning_level
 
-        # Use Braintrust tracing if configured
+        # Braintrust's wrap_openai does not support the Responses API
+        # streaming format (it assumes Chat Completions objects), causing
+        # AttributeError on stream finalization.  Use the raw client and
+        # initialise tracing separately so traced_span / log_to_span still work.
         if is_tracing_enabled():
             init_tracing()
-            from braintrust import wrap_openai
-
-            self.client = wrap_openai(OpenAI(api_key=self.api_key))
-        else:
-            self.client = OpenAI(api_key=self.api_key)
+        self.client = OpenAI(api_key=self.api_key)
 
     def _build_input(self, messages: list[Message]) -> list[dict[str, Any]]:
         """Convert messages to OpenAI Responses API input format."""

--- a/src/prompts/answer_evaluation.py
+++ b/src/prompts/answer_evaluation.py
@@ -4,7 +4,11 @@ Anything that is clearly a citation, regardless of format should be removed. Als
 Output the stripped string with no additional text or formatting changes.
 
 String to strip:
+```
 {answer_string}
+```
+
+CRITICAL: Output only the stripped string and nothing else. Only citations should be removed, everything else should be left unchanged.
 """.strip()
 
 

--- a/src/prompts/comparative_answer_eval.py
+++ b/src/prompts/comparative_answer_eval.py
@@ -10,15 +10,15 @@ DOCUMENT_TEMPLATE = """
 """
 
 COMPARATIVE_EVAL_PROMPT = """
-You are an answer comparison expert. Given a query, sets of backing documents, and two candidate answers, evaluate which answer is better and provide justification. \
-The two answers come from two different search systems and both provide their source documents. For documents which are retrieved by both systems, they are listed in the "Overlapping Documents" section. \
-Some documents may be marked as gold documents but this does not guarantee them to be the best documents for the query or sufficient on their own for a complete answer. \
-It is possible for other documents to even supersede and invalidate the gold documents. Sometimes neither system will retrieve the gold document so you may not see the label anywhere. \
-Your task is to evaluate the answers and determine if one system's answer is preferred over the other and if they are close to equivalent. \
-The two systems are considered equivalent if the answer contains very similar amounts of clearly useful information. \
-Discount but do not penalize information which is helpful but only peripherally related to the query or not directly relevant to the question. \
-Related information that might be helpful (but is not directly relevant to the question) should be considered positive however related information which may be misleading should be considered negative. \
-If an answer contains provably incorrect information based on the documents, it should be strongly penalized. Do not favor systems for being more or less "helpful" (ignore things like offering follow ups etc.).
+You are an expert answer evaluator. You will be given a query, two candidate answers from different search systems, and the documents each system retrieved.
+Documents retrieved by both systems appear under "Overlapping Documents". Some documents may be labeled as gold documents, but this label does not guarantee they are the best or only documents needed to answer the query — \
+other documents may supersede or invalidate them, and gold documents may not appear at all. Evaluate which answer better addresses the query, or whether the two are effectively equivalent. \
+Two answers are equivalent when they convey very similar amounts of clearly useful information. Apply the following guidelines:
+- Information that is peripherally related or not directly relevant to the query should neither be rewarded nor penalized.
+- Related information that is likely helpful to the user should be viewed positively, but related information that could mislead the user should be viewed negatively.
+- Do not favor a system for retrieving more documents. Additional documents only matter if the answer draws on them to be more correct or complete.
+- Provably incorrect information or unsubstanciated claims based on the provided documents should be strongly penalized.
+- Ignore stylistic differences such as helpfulness cues, follow-up suggestions, or formatting.
 
 ## Query:
 

--- a/src/prompts/comparative_answer_eval.py
+++ b/src/prompts/comparative_answer_eval.py
@@ -9,6 +9,8 @@ DOCUMENT_TEMPLATE = """
 ```
 """
 
+# Note, the gold answer is not provided to avoid biasing the LLM for answers that are similar in style and detail to the gold answer.
+# All of the relevant information is provided however since all of the expected documents and the ones retrieved by the systems are presented (up to a max document limit per system).
 COMPARATIVE_EVAL_PROMPT = """
 You are an expert answer evaluator. You will be given a query, two candidate answers from different search systems, and the documents each system retrieved.
 Documents retrieved by both systems appear under "Overlapping Documents". Some documents may be labeled as gold documents, but this label does not guarantee they are the best or only documents needed to answer the query — \
@@ -17,8 +19,10 @@ Two answers are equivalent when they convey very similar amounts of clearly usef
 - Information that is peripherally related or not directly relevant to the query should neither be rewarded nor penalized.
 - Related information that is likely helpful to the user should be viewed positively, but related information that could mislead the user should be viewed negatively.
 - Do not favor a system for retrieving more documents. Additional documents only matter if the answer draws on them to be more correct or complete.
+- It is possible some documents seem relevant but are actually misleading or incorrect.
 - Provably incorrect information or unsubstanciated claims based on the provided documents should be strongly penalized.
 - Ignore stylistic differences such as helpfulness cues, follow-up suggestions, or formatting.
+- If both answers are wrong according to the documents, favor the one that is less misleading.
 
 ## Query:
 
@@ -50,6 +54,11 @@ These are documents found by both systems.
 ## System 2 Retrieved Documents
 
 {retrieved_documents_2}
+
+## Missing Gold Documents
+
+These are documents that are expected to be in the gold document set but were not found by either system.
+{missing_gold_documents}
 
 ## Reminders
 

--- a/src/scripts/answer_evaluation/comparative_eval.py
+++ b/src/scripts/answer_evaluation/comparative_eval.py
@@ -335,8 +335,14 @@ def process_comparative_question(
     updated_q: dict | None = None
 
     if has_expected_docs:
-        union_doc_ids = set(docs_1) | set(docs_2)
-        candidate_only = sorted(d for d in union_doc_ids if d not in gold_set)
+        # Cap candidate (non-gold) docs at 10 per system
+        cands_1 = [d for d in docs_1 if d not in gold_set]
+        cands_2 = [d for d in docs_2 if d not in gold_set]
+        if len(cands_1) > 10:
+            cands_1 = random.sample(cands_1, 10)
+        if len(cands_2) > 10:
+            cands_2 = random.sample(cands_2, 10)
+        candidate_only = list(dict.fromkeys(cands_1 + cands_2))
 
         if candidate_only:
             eval_result, gold_confirmed, eval_error = evaluate_documents_with_consensus(
@@ -435,12 +441,25 @@ def process_comparative_question(
     )
     question_corrected = gold_answer_updated or docs_updated
 
-    # Compute overlapping/unique doc sets for comparison
+    # Compute overlapping/unique doc sets for comparison, capped at 15 docs
+    # per system. Overlapping docs count toward both systems' totals.
+    max_docs_per_system = 15
     set_1 = set(docs_1)
     set_2 = set(docs_2)
     overlapping = [d for d in docs_1 if d in set_2]
     only_1 = [d for d in docs_1 if d not in set_2]
     only_2 = [d for d in docs_2 if d not in set_1]
+
+    if len(overlapping) > max_docs_per_system:
+        overlapping = random.sample(overlapping, max_docs_per_system)
+        only_1 = []
+        only_2 = []
+    else:
+        remaining = max_docs_per_system - len(overlapping)
+        if len(only_1) > remaining:
+            only_1 = random.sample(only_1, remaining)
+        if len(only_2) > remaining:
+            only_2 = random.sample(only_2, remaining)
 
     effective_gold_set = set(effective_doc_ids)
 

--- a/src/scripts/answer_evaluation/comparative_eval.py
+++ b/src/scripts/answer_evaluation/comparative_eval.py
@@ -20,6 +20,8 @@ Args:
     --parallelism             Number of parallel evaluation threads (default: 1)
     --question-id             Evaluate a single question_id only
     --skip-citation-stripping Skip LLM-based citation stripping from answers
+    --resume              Skip questions already in results file
+    --limit               Max questions to process
 """
 
 import argparse
@@ -52,7 +54,6 @@ from src.prompts.comparative_answer_eval import (
     DOCUMENT_TEMPLATE,
     IS_GOLD_DOCUMENT_STR,
 )
-from src.utils.cli import confirm_yes_no
 from src.utils.document_index import (
     DEFAULT_UUID_INDEX_CACHE_FILE,
     load_document_content_by_uuid,
@@ -123,6 +124,11 @@ def compare_answers(
     system_2_text = format_document_section(
         only_2_doc_ids, gold_doc_ids, document_path_map
     )
+    presented_ids = set(overlapping_doc_ids) | set(only_1_doc_ids) | set(only_2_doc_ids)
+    missing_gold_ids = [d for d in gold_doc_ids if d not in presented_ids]
+    missing_gold_text = format_document_section(
+        missing_gold_ids, gold_doc_ids, document_path_map
+    )
 
     prompt = COMPARATIVE_EVAL_PROMPT.format(
         query=question,
@@ -131,6 +137,7 @@ def compare_answers(
         overlapping_documents=overlapping_text,
         retrieved_documents_1=system_1_text,
         retrieved_documents_2=system_2_text,
+        missing_gold_documents=missing_gold_text,
     )
 
     for attempt in range(_MAX_LLM_RETRIES):
@@ -539,6 +546,12 @@ def process_comparative_question(
         flipped_pref = "2" if comparison_result["preferred_system"] == "1" else "1"
         comparison_result["preferred_system"] = flipped_pref
 
+    comparison_result["reason"] = (
+        "Note that the LLM sees the two systems in a random order so the "
+        "referenced System 1/2 in the provided reasoning may be out of order. "
+        "LLM provided reasoning: " + comparison_result["reason"]
+    )
+
     return updated_q, {
         "question_id": qid,
         "corrected": question_corrected,
@@ -659,6 +672,8 @@ def build_comparative_question_type_stats(
 def write_comparative_results_snapshot(
     results_file: str,
     output_file: str,
+    answer_file_1: str,
+    answer_file_2: str,
     question_results: list[dict],
     skip_count: int | str,
     total_questions: int,
@@ -668,6 +683,8 @@ def write_comparative_results_snapshot(
     sorted_results = sort_question_results(question_results)
     stats = compute_comparative_stats(question_results)
     results_output = {
+        "system_1": answer_file_1,
+        "system_2": answer_file_2,
         "updated_question_file": output_file,
         "aggregate_stats": {
             "total_questions": total_questions,
@@ -745,6 +762,14 @@ def main() -> None:
         action="store_true",
         default=False,
         help="Skip LLM-based citation stripping from answers",
+    )
+    parser.add_argument(
+        "--resume",
+        action="store_true",
+        help="Skip questions already in results file",
+    )
+    parser.add_argument(
+        "--limit", type=int, default=None, help="Max questions to process"
     )
     args = parser.parse_args()
 
@@ -847,7 +872,7 @@ def main() -> None:
                     f"  [WARN] Could not load existing results from "
                     f"{args.results_file}, starting fresh"
                 )
-    elif os.path.exists(args.results_file):
+    elif args.resume and os.path.exists(args.results_file):
         try:
             existing_results = load_json_file(args.results_file)
             for r in existing_results.get("questions", []):
@@ -863,10 +888,10 @@ def main() -> None:
 
     valid_qids_set = set(valid_qids)
     new_qids = valid_qids_set - completed_qids
-    overlapping_qids = valid_qids_set & completed_qids
     is_resuming = False
 
     if completed_qids and not args.question_id:
+        overlapping_qids = valid_qids_set & completed_qids
         print(
             f"\n  Found {len(completed_qids)} already-evaluated questions "
             f"in {args.results_file}"
@@ -878,21 +903,10 @@ def main() -> None:
             print(f"\n  Resuming evaluation for {len(new_qids)} missing questions...")
             is_resuming = True
         else:
-            try:
-                if not confirm_yes_no(
-                    "All questions already evaluated. Re-run from scratch?",
-                    default=False,
-                    retry_on_invalid=True,
-                ):
-                    print("Aborted.")
-                    sys.exit(0)
-            except EOFError:
-                print("Aborted (non-interactive).")
-                sys.exit(0)
-            question_results.clear()
-            completed_qids.clear()
+            print("\n  All questions already evaluated, nothing to do.")
+            sys.exit(0)
     else:
-        print(f"\n  {len(valid_qids_set)} questions to evaluate (no prior results)")
+        print(f"\n  {len(valid_qids_set)} questions to evaluate")
 
     # =========================================================================
     # 3. Build and validate UUID path map
@@ -923,6 +937,10 @@ def main() -> None:
     # =========================================================================
 
     remaining_qids = [qid for qid in valid_qids if qid not in completed_qids]
+    if args.limit is not None:
+        remaining_qids = remaining_qids[: args.limit]
+        print(f"  Processing {len(remaining_qids)} questions (--limit {args.limit})")
+
     if args.question_id:
         total_questions = len(question_results) + len(valid_qids)
     else:
@@ -934,6 +952,8 @@ def main() -> None:
     write_comparative_results_snapshot(
         results_file=args.results_file,
         output_file=args.updated_questions_file,
+        answer_file_1=args.answer_file_1,
+        answer_file_2=args.answer_file_2,
         question_results=question_results,
         skip_count=display_skip_count,
         total_questions=total_questions,
@@ -970,6 +990,8 @@ def main() -> None:
         write_comparative_results_snapshot(
             results_file=args.results_file,
             output_file=args.updated_questions_file,
+            answer_file_1=args.answer_file_1,
+            answer_file_2=args.answer_file_2,
             question_results=question_results,
             skip_count=display_skip_count,
             total_questions=total_questions,
@@ -1017,6 +1039,8 @@ def main() -> None:
     write_comparative_results_snapshot(
         results_file=args.results_file,
         output_file=args.updated_questions_file,
+        answer_file_1=args.answer_file_1,
+        answer_file_2=args.answer_file_2,
         question_results=question_results,
         skip_count=display_skip_count,
         total_questions=total_questions,

--- a/src/scripts/answer_evaluation/metrics_based_eval.py
+++ b/src/scripts/answer_evaluation/metrics_based_eval.py
@@ -22,6 +22,7 @@ Args:
 import argparse
 import json
 import os
+import random
 import re
 import sys
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -149,8 +150,10 @@ def process_question_docs(
     if gold_set == answer_set:
         return (f"OK {qid}: document set matches gold", None)
 
-    # Find candidate docs that are not in the gold set
+    # Find candidate docs that are not in the gold set, capped at 20
     candidate_only = [d for d in deduped_doc_ids if d not in gold_set]
+    if len(candidate_only) > 20:
+        candidate_only = random.sample(candidate_only, 20)
 
     # Evaluate all documents (gold + candidates) with 3-run consensus
     eval_result, gold_confirmed, eval_error = evaluate_documents_with_consensus(

--- a/src/scripts/answer_evaluation/metrics_based_eval.py
+++ b/src/scripts/answer_evaluation/metrics_based_eval.py
@@ -17,6 +17,8 @@ Args:
     --parallelism             Number of parallel evaluation threads (default: 1)
     --question-id             Evaluate a single question_id only
     --skip-citation-stripping Skip LLM-based citation stripping from answers
+    --resume              Skip questions already in results file
+    --limit               Max questions to process
 """
 
 import argparse
@@ -45,7 +47,6 @@ from src.utils.eval_utils import (
 )
 from src.llm import Message, get_llm
 from src.prompts.answer_evaluation import ANSWER_WHOLISTIC_EVALUATION_PROMPT
-from src.utils.cli import confirm_yes_no
 from src.utils.document_index import DEFAULT_UUID_INDEX_CACHE_FILE
 from src.utils.file_io import load_json_file, write_json_file
 from src.utils.json_extraction import extract_json_from_response
@@ -329,11 +330,9 @@ def score_answer(
         correct_docs = answer_doc_set & expected_set
         document_recall_pct: float | None = len(correct_docs) / len(expected_set) * 100
         non_required = answer_doc_set - expected_set
-        valid_extra_docs: int | None = len(non_required & valid_doc_id_set)
         invalid_extra_docs: int | None = len(non_required - valid_doc_id_set)
     else:
         document_recall_pct = None
-        valid_extra_docs = None
         invalid_extra_docs = None
 
     # Answer completeness (fact-level) and correctness (wholistic) in parallel
@@ -577,6 +576,14 @@ def main() -> None:
         default=False,
         help="Skip LLM-based citation stripping from answers",
     )
+    parser.add_argument(
+        "--resume",
+        action="store_true",
+        help="Skip questions already in results file",
+    )
+    parser.add_argument(
+        "--limit", type=int, default=None, help="Max questions to process"
+    )
     args = parser.parse_args()
 
     # Validate input files exist
@@ -670,7 +677,7 @@ def main() -> None:
                     f"  [WARN] Could not load existing results from "
                     f"{args.results_file}, starting fresh"
                 )
-    elif os.path.exists(args.results_file):
+    elif args.resume and os.path.exists(args.results_file):
         try:
             existing_results = load_json_file(args.results_file)
             for r in existing_results.get("questions", []):
@@ -686,10 +693,10 @@ def main() -> None:
 
     answer_qids = {row["question_id"] for row in valid_rows}
     new_qids = answer_qids - completed_qids
-    overlapping_qids = answer_qids & completed_qids
     is_resuming = False
 
     if completed_qids and not args.question_id:
+        overlapping_qids = answer_qids & completed_qids
         print(
             f"\n  Found {len(completed_qids)} already-evaluated questions "
             f"in {args.results_file}"
@@ -698,27 +705,13 @@ def main() -> None:
         print(f"  {len(new_qids)} new questions to evaluate")
 
         if new_qids:
-            # Missing questions — resume automatically
             print(f"\n  Resuming evaluation for {len(new_qids)} missing questions...")
             is_resuming = True
         else:
-            # All questions already evaluated — ask to overwrite
-            try:
-                if not confirm_yes_no(
-                    "All questions already evaluated. Re-run from scratch?",
-                    default=False,
-                    retry_on_invalid=True,
-                ):
-                    print("Aborted.")
-                    sys.exit(0)
-            except EOFError:
-                print("Aborted (non-interactive).")
-                sys.exit(0)
-            # User chose to re-run: clear prior results
-            question_results.clear()
-            completed_qids.clear()
+            print("\n  All questions already evaluated, nothing to do.")
+            sys.exit(0)
     else:
-        print(f"\n  {len(answer_qids)} questions to evaluate (no prior results)")
+        print(f"\n  {len(answer_qids)} questions to evaluate")
 
     # =========================================================================
     # 3. Build and validate UUID path map
@@ -751,6 +744,10 @@ def main() -> None:
     remaining_rows = [
         row for row in valid_rows if row["question_id"] not in completed_qids
     ]
+    if args.limit is not None:
+        remaining_rows = remaining_rows[: args.limit]
+        print(f"  Processing {len(remaining_rows)} questions (--limit {args.limit})")
+
     if args.question_id:
         total_questions = len(question_results) + len(valid_rows)
     else:

--- a/src/utils/eval_utils.py
+++ b/src/utils/eval_utils.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import random
 import re
 
 from src.llm import Message, get_llm
@@ -267,8 +268,12 @@ def evaluate_documents(
         doc_data = load_document_json_by_uuid(dsid, document_path_map)
         gold_docs_text.append(format_document_for_doc_evaluation(dsid, doc_data))
 
+    # Shuffle candidates to avoid positional bias across consensus runs
+    shuffled_candidates = list(candidate_doc_ids)
+    random.shuffle(shuffled_candidates)
+
     candidate_docs_text = []
-    for dsid in candidate_doc_ids:
+    for dsid in shuffled_candidates:
         doc_data = load_document_json_by_uuid(dsid, document_path_map)
         candidate_docs_text.append(
             format_document_for_doc_evaluation(dsid, doc_data),

--- a/src/utils/eval_utils.py
+++ b/src/utils/eval_utils.py
@@ -229,8 +229,19 @@ def format_document_for_answer_update(title: str, content: str) -> str:
 # =============================================================================
 
 
+_DSID_PATTERN = re.compile(r"dsid_[a-f0-9]{20,32}")
+
+
+def _strip_dsid_references(text: str) -> str:
+    """Remove dsid_<hex> strings and clean up surrounding artifacts."""
+    cleaned = _DSID_PATTERN.sub("", text)
+    # Collapse whitespace runs left behind by removals
+    cleaned = re.sub(r" {2,}", " ", cleaned)
+    return cleaned.strip()
+
+
 def strip_answer_citations(answer: str) -> str:
-    """Strip citations from an answer string using LLM."""
+    """Strip citations from an answer string using LLM, then remove dsid references."""
     prompt = ANSWER_CITATION_STRIPPING_PROMPT.format(answer_string=answer)
 
     for attempt in range(_MAX_LLM_RETRIES):
@@ -244,11 +255,12 @@ def strip_answer_citations(answer: str) -> str:
                     response += chunk
 
             result = response.strip()
-            return result if result else answer
+            result = result if result else answer
+            return _strip_dsid_references(result)
         except Exception:
             if attempt == _MAX_LLM_RETRIES - 1:
                 raise
-    return answer
+    return _strip_dsid_references(answer)
 
 
 def evaluate_documents(


### PR DESCRIPTION
The eval previously took unlimited candidate docs from both systems. This poses a problem for systems that retrieve massive numbers of documents. Limiting to 30 max for comparative. This also limits for the metrics based eval (20 max). It is now impossible to for example hack the recall metric by simply returning the entire corpus for each question. The main purpose though is to avoid having too much irrelevant text in the eval prompts which can impact the fairness and cause unpredictable model behavior.

Also adding a bunch of misc improvements:
- Resume behavior for both eval scripts
- Removed problematic tracing 
- Added explanation for shuffling for comparative
- Programatic removal of dsids in citation removal step